### PR TITLE
adding parsing to error handler

### DIFF
--- a/core-ajax.html
+++ b/core-ajax.html
@@ -248,11 +248,11 @@ element.
     },
 
     processError: function(xhr) {
-      var response = xhr.status + ': ' + xhr.responseText;
+      var response = this.evalResponse(xhr);
       if (xhr === this.activeRequest) {
         this.error = response;
       }
-      this.fire('core-error', {response: response, xhr: xhr});
+      this.fire('core-error', {response: response, status: xhr.status, xhr: xhr});
     },
 
     processProgress: function(progress, xhr) {


### PR DESCRIPTION
error handling doesn't support parsing by the handleAs attribute. Status parameter passes the error code back to the callback so as to behave more consistently with the other methods
